### PR TITLE
fix(messages.mc): fix typo on binary message file

### DIFF
--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -166,7 +166,7 @@
       <ExcludedFromBuild>false</ExcludedFromBuild>
       <Command>mc %(FullPath)</Command>
       <Message>Compiling Messages...</Message>
-      <Outputs>%(Filename).rc;%(Filename).h;MSG0409.bin</Outputs>
+      <Outputs>%(Filename).rc;%(Filename).h;MSG00409.bin</Outputs>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
There is a typo on filename of (MSG0409.bin vs MSG00409.bin) which results with a warning while compiling the messages during the build process.

Output

```
warning MSB8065: Custom build for item "messages.mc" succeeded, but specified output "c:\users\purplemanul\source\repos\wsl-images\distrolauncher\msg0409.bin" has not been created. This may cause incremental build to work incorrectly.
```

Accordingly the Windows Language Code Identifier (LCID) Reference, Language ID for "en-US" Language tag is "0x0409".