### PR TITLE
fix: systemd on user level

### DIFF
--- a/rootfs/almalinux_10_ARM64.sh
+++ b/rootfs/almalinux_10_ARM64.sh
@@ -97,18 +97,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \

--- a/rootfs/almalinux_10_x64.sh
+++ b/rootfs/almalinux_10_x64.sh
@@ -96,18 +96,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \

--- a/rootfs/almalinux_8_ARM64.sh
+++ b/rootfs/almalinux_8_ARM64.sh
@@ -97,18 +97,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \

--- a/rootfs/almalinux_8_x64.sh
+++ b/rootfs/almalinux_8_x64.sh
@@ -96,18 +96,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \

--- a/rootfs/almalinux_9_ARM64.sh
+++ b/rootfs/almalinux_9_ARM64.sh
@@ -97,18 +97,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \

--- a/rootfs/almalinux_9_x64.sh
+++ b/rootfs/almalinux_9_x64.sh
@@ -96,18 +96,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \

--- a/rootfs/almalinux_kitten_10_ARM64.sh
+++ b/rootfs/almalinux_kitten_10_ARM64.sh
@@ -96,18 +96,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \

--- a/rootfs/almalinux_kitten_10_x64.sh
+++ b/rootfs/almalinux_kitten_10_x64.sh
@@ -95,18 +95,6 @@ buildah copy --chmod 0644 "$wsl_builder_ct" rootfs/terminal-profile.json /rootfs
 buildah copy --from="$wsl_builder_ct" "$wsl_ct" /rootfs /
 
 
-buildah run "$wsl_ct" -- systemctl mask \
-    systemd-remount-fs.service \
-    dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
-    systemd-logind.service \
-    getty.target \
-    console-getty.service \
-    systemd-udev-trigger.service \
-    systemd-udevd.service \
-    systemd-random-seed.service \
-    systemd-machine-id-commit.service
-
 # https://learn.microsoft.com/en-us/windows/wsl/build-custom-distro#systemd-recommendations
 buildah run "$wsl_ct" -- systemctl mask \
     systemd-resolved.service \


### PR DESCRIPTION
We were masking some systemd units in two parts:

1. Due the similar nature, the WSL images inherited masking of some systemd units from the init containers.

2. There is also a list of systemd units are recommended to be masked by the official WSL documentation with introduction of the new packaging format and installation format.

Dropping the first part lets systemd work in user level too. So, instead of hunting down on which units breaks user level support when it is masked, it is better to only rely on the official WSL documentation, which built from the WSL specific reports.

fixes #56 