### PR TITLE
ci: automate publishing and update documentation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,115 @@
+name: Publish with Pull Request
+on:
+  workflow_dispatch:
+    inputs:
+      almalinux_chat_notiy:
+        description: 'Notify AlmaLinux Chat'
+        default: true
+        type: boolean
+      almalinux_chat_channel:
+        description: 'Channel name on AlmaLinux Chat'
+        default: sigcloud
+        type: string
+jobs:
+  create_publishing_pr:
+    name: Create publishing PR
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Generate distribution manifest
+        run: uv run tools/distribution_manifest_updater.py
+
+      - name: Download upstream distribution manifest
+        run: curl -LO https://raw.githubusercontent.com/microsoft/WSL/refs/heads/master/distributions/DistributionInfo.json
+
+      - name: Compare distribution manifests
+        id: diff_exit_code
+        run: |
+          trap 'echo "diff_exit_code=$?" >> "$GITHUB_OUTPUT"' EXIT
+          git diff --no-index DistributionInfo.json DistributionInfo_generated.json
+        continue-on-error: true
+
+      - name: Checkout WSL repository
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/WSL
+          path: almalinux_wsl
+          token: ${{ secrets.GH_WSL_PAT }}
+
+      - name: Git configure
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        working-directory: ./almalinux_wsl
+
+      - name: Git add upstream remote
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: git remote add -f -t master --no-tags microsoft https://github.com/microsoft/WSL.git
+        working-directory: ./almalinux_wsl
+
+      - name: Git remove old publishing branch
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: git push -d origin publishing_pr
+        working-directory: ./almalinux_wsl
+        continue-on-error: true
+
+      - name: Git create and checkout to publishing branch
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: git checkout -b publishing_pr microsoft/master
+        working-directory: ./almalinux_wsl
+
+      - name: Update distribution manifest
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: cp -v DistributionInfo_generated.json almalinux_wsl/distributions/DistributionInfo.json
+
+      - name: Run validation
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: |
+          uv run --with-requirements distributions/requirements.txt distributions/validate-modern.py \
+              --repo-path . \
+              --compare-with-branch microsoft/master \
+              --manifest distributions/DistributionInfo.json
+        working-directory: ./almalinux_wsl
+
+      - name: Git commit changes
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: |
+          git add ./distributions/DistributionInfo.json
+          git commit -m 'chore(distributions): update almalinux'
+        working-directory: ./almalinux_wsl
+
+      - name: Git push commit
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        run: git push origin publishing_pr
+        working-directory: ./almalinux_wsl
+
+      - name: Create a PR
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' }}
+        id: create_pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_WSL_PAT }}
+        run: |
+          echo "pr_url=$(gh pr create --repo microsoft/WSL --fill-first \
+              --assignee $GITHUB_ACTOR \
+              --body "This automated release was created by $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          Maintainers: @$GITHUB_ACTOR")" >> "$GITHUB_OUTPUT"
+        working-directory: ./almalinux_wsl
+
+      - name: Notify
+        if: ${{ steps.diff_exit_code.outputs.diff_exit_code == '1' && inputs.almalinux_chat_notiy }}
+        uses: mattermost/action-mattermost-notify@2.0.0
+        with:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}
+          MATTERMOST_CHANNEL: ${{ inputs.almalinux_chat_channel }}
+          MATTERMOST_USERNAME: 'github'
+          TEXT: |
+            ##### [PUBLISH]: A submission has been created for the new releases of WSL images
+            ###### Pull Request
+            :almalinux: ${{ steps.create_pr.outputs.pr_url }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# AlmaLinux OS for Windows Subsystem for Linux (WSL)
+
+## Get started
+
+The WSL section of AlmaLinux Wiki has a comprehensive guide which covers from installation of WSL and distributions like AlmaLinux OS to extras features like running GUI apps and Docker desktop integration: https://wiki.almalinux.org/documentation/wsl.html
+
+## Installation
+
+Publishing is done by creating pull requests on https://github.com/microsoft/WSL to update the distributions manifest, which is used by wsl command-line tool during the download and installation.
+
+These images can also be downloaded from the releases section of this GitHub repository, which can be useful for offline installations via `wsl --install --from-file`.
+
+## Documentation
+
+The `docs` directoy is used to store documentation about how building, testing and publishing is done.

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,6 +1,45 @@
-# How to build AlmaLinux OS Windows Subsystem for Linux images as a Windows application
+# How to build AlmaLinux OS Windows Subsystem for Linux images
 
-## Requirements
+## WSL format (`.wsl`)
+
+Shell scripts and configuration files are stored on `rootfs` to build RootFS in `.wsl` format.
+
+### Requirements
+- [Buildah](https://github.com/containers/buildah/blob/main/install.md)
+- [jq](https://jqlang.org/download/)
+
+## Build
+
+Each distro and major version has own builder scripts. Each scripts has these positional parameters:
+- `minor_version`: Minor version of AlmaLinux OS 10. By default it's set to latest (e.g. 0 for 10.0).
+- `build_number`: The build number of the version. Default value is the `0` as a first build of a version.
+
+Example: AlmaLinux OS 10 with default minor version (`0` for `10.0`) and build number (e.g. `20250801.0`).
+
+With default values.
+
+```sh
+bash -x rootfs/almalinux_10_x64.sh
+```
+
+With custom values for AlmaLinux OS 10.1.
+
+```sh
+# bash -x rootfs/almalinux_10_x64.sh minor_version build_number
+bash -x rootfs/almalinux_10_x64.sh 1 0
+```
+
+Output: `AlmaLinux-10."${minor_version}"_x64_"${build_version}".wsl`
+
+## Install
+
+```sh
+wsl --install --from-file $IMAGE
+```
+
+## Microsoft App (legacy)
+
+### Requirements
 
 1. Use [WinGet](https://github.com/microsoft/winget-cli) as a package manager to install build tools. Please, consult to the official [documentation](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget) for the installation guide.
 
@@ -47,7 +86,7 @@ to able to install apps outside of Microsoft Store.
 
 ## Extras
 
-Additional tools might be usefuful.
+Additional tools might be useful.
 ```powershell
 winget upgrade --all
 winget install Microsoft.PowerShell Microsoft.WindowsTerminal Microsoft.OpenSSH.Beta Git.Git cURL.cURL jqlang.jq Neovim.Neovim

--- a/docs/Publishing.md
+++ b/docs/Publishing.md
@@ -1,0 +1,25 @@
+# How to publish AlmaLinux OS WSL images
+
+## Automated
+
+### GitHub Actions
+
+#### Build
+
+The building workflows are divided for each distributions (AlmaLinux OS and AlmaLinux OS Kitten) and major versions (AlmaLinux OS 8, 9, 10 and AlmaLinux OS Kitten 10). The workflows can be started in two modes; [Test](#test) and [Release](#release).
+
+##### Test
+
+The purpose of this mode to use an object storage to store build artifacts during the development and testing.
+Required inputs:
+- **Release on GitHub**: `false`
+
+##### Release
+
+The purpose of this mode to use GitHub releases to store stable build artifacts which are used for [publishing](#publish).
+Required inputs:
+- **Release on GitHub**: `true`
+
+#### Publish
+
+The Publish with Pull Request (`publish.yaml`) workflow creates a pull request to https://github.com/microsoft/WSL with updated version of distribution manifest. Which is generated from the artifacts uploaded on [Release](#release).

--- a/tools/distribution_manifest_updater.py
+++ b/tools/distribution_manifest_updater.py
@@ -1,0 +1,233 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "requests<3",
+# ]
+# ///
+from json import dump
+from logging import INFO, basicConfig, getLogger
+from pathlib import Path
+from sys import stdout
+
+from requests import HTTPError, get
+
+GITHUB_ORG = 'AlmaLinux'
+GITHUB_REPO = 'wsl-images'
+DISTRIBUTION_MANIFEST_UPSTREAM = 'https://raw.githubusercontent.com/microsoft/WSL/refs/heads/master/distributions/DistributionInfo.json'
+DISTROS = {
+    'AlmaLinux-8': 'AlmaLinux OS 8',
+    'AlmaLinux-9': 'AlmaLinux OS 9',
+    'AlmaLinux-10': 'AlmaLinux OS 10',
+    'AlmaLinux-Kitten-10': 'AlmaLinux OS Kitten 10',
+}
+
+logger = getLogger(__name__)
+
+
+def configure_logging():
+    """Configure logging.
+
+    Configure standard output (stdout) for logging output.
+    """
+    basicConfig(level=INFO, stream=stdout)
+    return logger
+
+
+def get_releases(gh_org, gh_repo):
+    """Gets releases from a GitHub repository.
+
+    Uses GitHub REST API to retrieve GitHub releases.
+    Checks for available versions of GitHub REST API,
+    gives a warning when the used version (gh_api_version)
+    is not latest anymore.
+    When a new version of GitHub REST API is available,
+    HTTP status code 400 will be returned after the support for
+    the old version ends. Which is 24 months after a new version is released.
+
+    :param gh_org: Name of a GitHub organization.
+    :type gh_org: str
+    :param gh_repo: Name of a GitHub repository.
+    :type gh_repo: str
+    :raises HTTPError: If GitHub REST API version is depreciated.
+    :returns: GitHub releases.
+    :rtype: dict
+    """
+    gh_api = 'https://api.github.com'
+    gh_api_version = '2022-11-28'
+    gh_api_headers = {
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': f'{gh_api_version}',
+    }
+    gh_api_releases = f'{gh_api}/repos/{gh_org}/{gh_repo}/releases'
+
+    gh_api_versions = get(f'{gh_api}/versions', headers=gh_api_headers).json()
+    if gh_api_versions[0] != gh_api_version:
+        logger.warning(
+            'A new version of the GitHub REST API is available. Please update to the new version.'
+        )
+
+    try:
+        response_releases = get(
+            gh_api_releases,
+            headers=gh_api_headers,
+        )
+        response_releases.raise_for_status()
+        return response_releases.json()
+
+    except HTTPError as http_error:
+        if http_error.response.status_code == 400:
+            logger.exception(
+                f'The GitHub REST API version {gh_api_version} is deprecated.'
+            )
+
+
+def get_releases_by_distro(distro_friendly_name, releases):
+    """Get GitHub releases for a distribution.
+
+    :param distro_friendly_name: Friendly name of a distro, e.g., AlmaLinux OS 10.
+    :type distro_friendly_name: str
+    :param releases: GitHub releases for a repository.
+    :type releases: dict
+    :returns: Distro specific version of GitHub releases.
+    :rtype: list
+    """
+    distro_releases = [
+        release
+        for release in releases
+        if release['name'].startswith(distro_friendly_name)
+    ]
+    return distro_releases
+
+
+def get_latest_release(release_distro):
+    """Get the latest GitHub release
+
+    The order of releases that are returned by GitHub REST API
+    is descending by date. Which means the first release is the latest.
+
+    :param release_distro: GitHub releases of a distro.
+    :type release_distro: list
+    :returns: The latest GitHub release of a distro.
+    :rtype: dict
+    """
+    return release_distro[0]
+
+
+def get_release_assets_by_distro(distro_name, distro_release):
+    """Get assets from a distro specific GitHub release
+
+    :param distro_name: Name of a distro.
+    :type distro_name: str
+    :param distro_release: GitHub release of a distro.
+    :type distro_release: dict
+    :returns: Assets of a GitHub release.
+    :rtype: dict
+    """
+    x64_image_url = ''
+    x64_image_checksum = ''
+    arm64_image_url = ''
+    arm64_image_checksum = ''
+
+    for asset in distro_release['assets']:
+        if 'x64' in asset['name']:
+            if asset['name'].endswith('.wsl'):
+                x64_image_url = asset['browser_download_url']
+            else:
+                x64_image_checksum = get(asset['browser_download_url']).text.partition(
+                    ' '
+                )[0]
+        else:
+            if asset['name'].endswith('.wsl'):
+                arm64_image_url = asset['browser_download_url']
+            else:
+                arm64_image_checksum = get(
+                    asset['browser_download_url']
+                ).text.partition(' ')[0]
+
+    distro_release_assets = {
+        'distro': distro_name,
+        'image_url_x64': x64_image_url,
+        'image_checksum_x64': x64_image_checksum,
+        'image_url_arm64': arm64_image_url,
+        'image_checksum_arm64': arm64_image_checksum,
+    }
+
+    return distro_release_assets
+
+
+def generate_distribution_manifest(distro_assets):
+    """Generate distribution manifest
+
+    :param distro_assets: Assets of a distro.
+    :type distro_assets: list
+    :returns: Distribution manifest.
+    :rtype: dict
+    """
+    distribution_manifest = get(DISTRIBUTION_MANIFEST_UPSTREAM).json()
+
+    for distribution in distribution_manifest['ModernDistributions']['AlmaLinux']:
+        for distro_asset in distro_assets:
+            if distribution['Name'] == distro_asset['distro']:
+                distribution['Amd64Url']['Url'] = distro_asset['image_url_x64']
+                distribution['Amd64Url']['Sha256'] = distro_asset['image_checksum_x64']
+                distribution['Arm64Url']['Url'] = distro_asset['image_url_arm64']
+                distribution['Arm64Url']['Sha256'] = distro_asset[
+                    'image_checksum_arm64'
+                ]
+    return distribution_manifest
+
+
+def create_distribution_manifest_file(distribution_manifest):
+    """Write a distribution manifest into a file after serializing it as a JSON.
+
+    :param distribution_manifest: Distribution manifest.
+    :type distribution_manifest: dict
+    """
+    distribution_manifest_path = (
+        Path(__name__).parent / 'DistributionInfo_generated.json'
+    )
+
+    with distribution_manifest_path.open('w') as file:
+        dump(distribution_manifest, file, indent=4)
+        file.write('\n')
+
+    logger.info(
+        f'The Distribution manifest created on: {distribution_manifest_path.resolve()}'
+    )
+
+
+def main():
+    log = configure_logging()
+    releases = get_releases(GITHUB_ORG, GITHUB_REPO)
+    distro_assets = []
+
+    log.info('The new distribution manifest will be created with these release assets')
+
+    for distro_name, distro_friendly_name in DISTROS.items():
+        distro_releases = get_releases_by_distro(distro_friendly_name, releases)
+        distro_release_latest = get_latest_release(distro_releases)
+        distro_release_assets = get_release_assets_by_distro(
+            distro_name, distro_release_latest
+        )
+
+        log.info(
+            f'{distro_friendly_name} Image URL (x64): {distro_release_assets["image_url_x64"]}'
+        )
+        log.info(
+            f'{distro_friendly_name} Image Checksum (x64): {distro_release_assets["image_checksum_x64"]}'
+        )
+        log.info(
+            f'{distro_friendly_name} Image URL (ARM64): {distro_release_assets["image_url_arm64"]}'
+        )
+        log.info(
+            f'{distro_friendly_name} Image Checksum (ARM64): {distro_release_assets["image_checksum_arm64"]}'
+        )
+
+        distro_assets.append(distro_release_assets)
+
+    distribution_manifest = generate_distribution_manifest(distro_assets)
+    create_distribution_manifest_file(distribution_manifest)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
ci:
- .github/workflows/publish.yaml: Create a workflow to submit generated distribution manifest as a pull request for publishing.

tooling:
- tools/distribution_manifest_updater.py: Create a tool to automatically generate a new distribution manifest for the latest releases of images.

docs:
- README.md: Create a project README.
- docs/Building.md: Update building guide with the WSL native format and mark the Microsoft docs/Publishing.md
- docs/Publishing.md: Create a documentation about how to use automation of publishing.