### PR TITLE
chore(ci): align S3 paths with cloud-images layout

### DIFF
--- a/.github/workflows/almalinux_10.yaml
+++ b/.github/workflows/almalinux_10.yaml
@@ -78,16 +78,16 @@ jobs:
           AWS_DEFAULT_REGION: 'us-east-1'
         run: |
           aws s3 cp . \
-              s3://almalinux-cloud/images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/ \
+              s3://almalinux-cloud/images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/ \
               --recursive \
               --exclude '*' --include '*.wsl*'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
+              --key images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
               --tagging 'TagSet={Key=public,Value=yes}'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
+              --key images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
               --tagging 'TagSet={Key=public,Value=yes}'
   release:
     if: ${{ inputs.release }}
@@ -125,12 +125,12 @@ jobs:
     steps:
       - name: Notify AlmaLinux Chat
         env:
-          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          image_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
-          checksum_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
-          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          image_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          checksum_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/10/10.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-10.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
         uses: mattermost/action-mattermost-notify@master
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}

--- a/.github/workflows/almalinux_8.yaml
+++ b/.github/workflows/almalinux_8.yaml
@@ -75,16 +75,16 @@ jobs:
           AWS_DEFAULT_REGION: 'us-east-1'
         run: |
           aws s3 cp . \
-              s3://almalinux-cloud/images/almalinux/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/ \
+              s3://almalinux-cloud/images/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/ \
               --recursive \
               --exclude '*' --include '*.wsl*'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
+              --key images/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
               --tagging 'TagSet={Key=public,Value=yes}'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
+              --key images/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
               --tagging 'TagSet={Key=public,Value=yes}'
   release:
     if: ${{ inputs.release }}
@@ -122,10 +122,10 @@ jobs:
     steps:
       - name: Notify AlmaLinux Chat
         env:
-          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
-          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/8/8.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-8.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
         uses: mattermost/action-mattermost-notify@master
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}

--- a/.github/workflows/almalinux_9.yaml
+++ b/.github/workflows/almalinux_9.yaml
@@ -75,16 +75,16 @@ jobs:
           AWS_DEFAULT_REGION: 'us-east-1'
         run: |
           aws s3 cp . \
-              s3://almalinux-cloud/images/almalinux/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/ \
+              s3://almalinux-cloud/images/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/ \
               --recursive \
               --exclude '*' --include '*.wsl*'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
+              --key images/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
               --tagging 'TagSet={Key=public,Value=yes}'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
+              --key images/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
               --tagging 'TagSet={Key=public,Value=yes}'
   release:
     if: ${{ inputs.release }}
@@ -122,10 +122,10 @@ jobs:
     steps:
       - name: Notify AlmaLinux Chat
         env:
-          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
-          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/9/9.${{ inputs.minor_version }}/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-9.${{ inputs.minor_version }}_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
         uses: mattermost/action-mattermost-notify@master
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}

--- a/.github/workflows/almalinux_kitten_10.yaml
+++ b/.github/workflows/almalinux_kitten_10.yaml
@@ -74,16 +74,16 @@ jobs:
           AWS_DEFAULT_REGION: 'us-east-1'
         run: |
           aws s3 cp . \
-              s3://almalinux-cloud/images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/ \
+              s3://almalinux-cloud/images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/ \
               --recursive \
               --exclude '*' --include '*.wsl*'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
+              --key images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl \
               --tagging 'TagSet={Key=public,Value=yes}'
           aws s3api put-object-tagging \
               --bucket almalinux-cloud \
-              --key images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
+              --key images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_${{ matrix.architecture }}_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum \
               --tagging 'TagSet={Key=public,Value=yes}'
   release:
     if: ${{ inputs.release }}
@@ -121,12 +121,12 @@ jobs:
     steps:
       - name: Notify AlmaLinux Chat
         env:
-          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          image_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
-          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
-          checksum_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
-          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/almalinux-kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          image_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          image_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          image_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl
+          checksum_url_x64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          checksum_url_x64_v2: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_x64_v2_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
+          checksum_url_ARM64: https://almalinux-cloud.s3-accelerate.dualstack.amazonaws.com/images/kitten/10/wsl/${{ needs.prepare.outputs.timestamp }}/AlmaLinux-Kitten-10_ARM64_${{ needs.prepare.outputs.version }}.${{ inputs.build_number }}.wsl.sha256sum
         uses: mattermost/action-mattermost-notify@master
         with:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_URL }}


### PR DESCRIPTION
Drop the `almalinux/` prefix from AlmaLinux 8/9/10 upload paths and rename `almalinux-kitten/` to `kitten/` so WSL image uploads land under the same `images/<flavor>/<version>/` layout used by the cloud-images project.